### PR TITLE
Swap out shebangs for /usr/bin/env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ perl:
     - "5.14"
     - "5.12"
     - "5.10"
-script: "./snazzer-prune-candidates --test"
+script: "perl -w snazzer-prune-candidates --test"
 install: true

--- a/doc/examples/etc/cron.daily/snazzer
+++ b/doc/examples/etc/cron.daily/snazzer
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e
 . /etc/default/snazzer
 snazzer --all

--- a/doc/examples/etc/cron.daily/snazzer-receive
+++ b/doc/examples/etc/cron.daily/snazzer-receive
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e
 su receiveruser -c "/bin/sh snazzer-receive.sh"

--- a/doc/examples/etc/cron.daily/snazzer-receive.sh
+++ b/doc/examples/etc/cron.daily/snazzer-receive.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e
 . /etc/default/snazzer
 . /etc/snazzer/receive-config

--- a/snazzer
+++ b/snazzer
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e
 SNAZZER_VERSION=0.2
 SNAZZER_MEAS_LOCK_DIR="/var/lock/snazzer-measure.lock"

--- a/snazzer-measure
+++ b/snazzer-measure
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -e
 SNAZZER_VERSION=0.5

--- a/snazzer-prune-candidates
+++ b/snazzer-prune-candidates
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 package App::Snazzer::Prune;
 use strict;
 use warnings;

--- a/snazzer-receive
+++ b/snazzer-receive
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e
 SNAZZER_VERSION=0.3
 SNAZZER_SNAPSHOTZ_PERMS=0755

--- a/snazzer-send-wrapper
+++ b/snazzer-send-wrapper
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/usr/bin/env sh -e
 set -e
 export PATH=/bin:/usr/bin:/sbin:/usr/local/bin
 

--- a/tests/data/sudo
+++ b/tests/data/sudo
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 case "$F" in
     no_args)
         echo $#;

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 su_do() {
     if [ "$(id -u)" = "0" ]; then


### PR DESCRIPTION
Hi @csirac2! I've been looking around for a good btrfs snapshotter and you've made something great here, thanks for all the work on this great project!

This looks like a superfluous PR, I know, but I'm attempting to use snazzer on [NixOS](http://nixos.org/) which has a non-standard `PATH` setup, but does honor the `env` paradigm when needed by shebangs in scripts. This should really be a pretty safe change for existing use cases and make the script usable for environments that don't necessarily have binaries in the paths hard-coded into the shebang.
