### PR TITLE
remove -w in shebang for perl execution

### DIFF
--- a/snazzer-prune-candidates
+++ b/snazzer-prune-candidates
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 package App::Snazzer::Prune;
 use strict;
 use warnings;


### PR DESCRIPTION
as env only accepts a single argument on some systems, and use warnings; is used anyway.
