### PR TITLE
take exclude lines for whole file path

### DIFF
--- a/doc/examples/etc/snazzer/exclude.patterns
+++ b/doc/examples/etc/snazzer/exclude.patterns
@@ -1,6 +1,6 @@
 var/cache
-var/lib/docker
+var/lib/docker/*
 .snapshots
-*tmp*
+tmp
 *backup*
 *secret*

--- a/snazzer
+++ b/snazzer
@@ -30,9 +30,9 @@ if ! $SUDO test -e "$SNAZZER_SUBVOLS_EXCLUDE_FILE"; then
     SNAZZER_SUBVOLS_EXCLUDE_FILE=$(mktemp)
     cat <<HERE > "$SNAZZER_SUBVOLS_EXCLUDE_FILE"
 var/cache
-var/lib/docker
+var/lib/docker/*
 .snapshots
-*tmp*
+tmp
 *backup*
 *secret*
 HERE
@@ -723,8 +723,10 @@ snapshots already measured by current hostname
 Filename of newline separated list of shell glob patterns of subvolume pathnames
 which should be excluded from C<snazzer --all> invocations; compatible with
 C<--exclude-from> for B<du> and B<tar>.  Examples of subvolume patterns to
-exclude from regular snapshotting: *secret*, /var/cache, /var/lib/docker/btrfs,
-.snapshots.  B<NOTE:> C<.snapshotz> is always excluded.
+exclude from regular snapshotting: *secret*, var/cache, var/lib/docker/*,
+.snapshots. The patterns are matched against subvolumes as listed by
+C<btrfs subvolume list <path>>, without a leading /.
+Note that   B<NOTE:> C<.snapshotz> is always excluded.
 Default:
 
   SNAZZER_SUBVOLS_EXCLUDE_FILE="/etc/snazzer/exclude.patterns"

--- a/snazzer
+++ b/snazzer
@@ -75,7 +75,11 @@ glob2grep_file() {
     FILE=$1
     OUT=$(mktemp)
 
-    sed 's|[$.^]|\\&|g' "$FILE" | sed 's/\*/\.*/g' > "$OUT"
+    # first, escape $, . and ^ with a backslash so they're taken literally
+    # then, extend * to .* to emulate shell globbing.
+    # finally, add ^ and $ to the line ends so the lines are not evaluated as *line*
+    sed 's|[$.^]|\\&|g' "$FILE" | sed 's/\*/\.*/g' | sed 's/^/\^/g' | sed 's/$/\$/g' > "$OUT"
+
 
     echo "$OUT"
 }


### PR DESCRIPTION
Because the usage of grep -f, each line inside `/etc/snazzer/exclude.patterns` currently behaves like it would have been surrounded by _-globs, making `tmp` essentially the same as `_tmp*`.

I think this current behaviour is inconsistent with the exclude patterns of du and tar and this change would make it consistent, but I'm not sure. Would fix #30.

This change should be backwards-compatible in all cases, except when people had lines like `tmp` but expected them to be evaluated as `*tmp*`. Maybe the manpage mention of `.snapshots` would need to be updated as well.
