### PR TITLE
Makefile umask compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ INSTALL_PREFIX:=/usr/local/bin
 $(INSTALL_PREFIX)/%: %
 	cp $< $@
 
-install: $(shell find . -maxdepth 1 -perm -111 -type f \
+install: $(shell find . -maxdepth 1 -executable -type f \
 	-printf '$(INSTALL_PREFIX)/%p\n' )
 
 uninstall:
-	rm $(shell find . -maxdepth 1 -perm -111 -type f \
+	rm $(shell find . -maxdepth 1 -executable -type f \
 	   	-printf '$(INSTALL_PREFIX)/%p\n')
 
 clean:
@@ -30,10 +30,10 @@ bats:
 prune-tests:
 	./snazzer-prune-candidates --tests
 
-markdown: $(shell find . -maxdepth 1 -perm -111 -type f -printf 'doc/%p.md\n')\
+markdown: $(shell find . -maxdepth 1 -executable -type f -printf 'doc/%p.md\n')\
    	| doc
 
-manpages: $(shell find . -maxdepth 1 -perm -111 -type f -printf 'man/%p.8\n') \
+manpages: $(shell find . -maxdepth 1 -executable -type f -printf 'man/%p.8\n') \
 	| man
 
 man/%.8: %

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: markdown manpages
 INSTALL_PREFIX:=/usr/local/bin
 
 $(INSTALL_PREFIX)/%: %
-	cp $< $@
+	install -Dm755 $< $@
 
 install: $(shell find . -maxdepth 1 -executable -type f \
 	-printf '$(INSTALL_PREFIX)/%p\n' )


### PR DESCRIPTION
The current Makefile does not work with umasks like `0007` (needed on multi-user machines where you don't want others to read your home directories. :wink: ). To fix this, this PR makes find test for executability in general and not requiring all executable bits to be set, and explicitly sets the permissions on installing. This will also help packaging, where `INSTALL_PREFIX` is actually a local diretory owned by the user.
