### PR TITLE
tests: make failure message output from bats useful

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ bats-tests: | bats
 	PATH=.:$$PATH bats tests/
 
 bats:
-	PATH=.:$$PATH bats --help >/dev/null || (                   \
+	@PATH=.:$$PATH bats --help >/dev/null || (                  \
 		mkdir tmp;                                              \
 		git clone https://github.com/sstephenson/bats tmp/bats; \
 		ln -s tmp/bats/bin/bats .;                              \

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -162,3 +162,13 @@ snapshot_mnt() {
 
     rm "$TMP_DATES"
 }
+
+expected_file() {
+    echo "$BATS_TMPDIR/snazzer-tests/$(basename \
+        $BATS_TEST_FILENAME)_${BATS_TEST_NUMBER}${1}.expected"
+}
+
+actual_file() {
+    echo "$BATS_TMPDIR/snazzer-tests/$(basename \
+        $BATS_TEST_FILENAME)_${BATS_TEST_NUMBER}${1}.actual"
+}

--- a/tests/snazzer-list.bats
+++ b/tests/snazzer-list.bats
@@ -37,26 +37,25 @@ HERE
 }
 
 @test "snazzer in PATH" {
-    local THIS_SNAZZER=$(readlink -f $BATS_TEST_DIRNAME/../snazzer)
-    local PATH_SNAZZER=$(readlink -f $(which snazzer))
-    
-    [ -n "$PATH_SNAZZER" ]
-    [ -n "$THIS_SNAZZER" ]
-    [ "$PATH_SNAZZER" = "$THIS_SNAZZER" ]
+    readlink -f $BATS_TEST_DIRNAME/../snazzer > $(expected_file)
+    readlink -f $(which snazzer) > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
 }
 
 @test "snazzer --list-subvolumes --all [mountpoint]" {
     run snazzer --list-subvolumes --all "$MNT"
     [ "$status" = "0" ]
-    echo "$output" > /tmp/output
-    echo "$(expected_list_subvolumes_output)" > /tmp/expected
-    [ "$output" = "$(expected_list_subvolumes_output)" ]
+    expected_list_subvolumes_output > $(expected_file)
+    echo "$output" > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
 }
 
 @test "snazzer --list-snapshots --all [mountpoint]" {
     run snazzer --list-snapshots --all "$MNT"
     [ "$status" = "0" ]
-    [ "$output" = "$(expected_list_snapshots_output)" ]
+    expected_list_snapshots_output > $(expected_file)
+    echo "$output" > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
 }
 
 @test "snazzer --list-snapshots --all [mountpoint/subvol]" {
@@ -67,15 +66,19 @@ HERE
 @test "snazzer --list-snapshots [/subvol1]" {
     run snazzer --list-snapshots "$MNT/home"
     [ "$status" = "0" ]
-    [ "$output" = "$(expected_list_snapshots_output | grep "^$MNT/home")" ]
+    expected_list_snapshots_output | grep "^$MNT/home" > $(expected_file)
+    echo "$output" > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
 }
 
 @test "snazzer --list-snapshots [/subvol1] [/subvol2] [/subvol3]" {
     run snazzer --list-snapshots "$MNT/home" "$MNT/srv" "$MNT/var/cache"
     [ "$status" = "0" ]
-    [ "$(expected_list_snapshots_output | \
-        grep "^$MNT/\(home\|srv\|var/cache\)/\.snapshotz" |sort)" = "$output" ]
-    
+    expected_list_snapshots_output | \
+        grep "^$MNT/\(home\|srv\|var/cache\)/\.snapshotz" | \
+        sort > $(expected_file)
+    echo "$output" > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
 }
 
 teardown() {

--- a/tests/snazzer-list.bats
+++ b/tests/snazzer-list.bats
@@ -44,18 +44,18 @@ HERE
 
 @test "snazzer --list-subvolumes --all [mountpoint]" {
     run snazzer --list-subvolumes --all "$MNT"
-    [ "$status" = "0" ]
     expected_list_subvolumes_output > $(expected_file)
     echo "$output" > $(actual_file)
     diff -u $(expected_file) $(actual_file)
+    [ "$status" = "0" ]
 }
 
 @test "snazzer --list-snapshots --all [mountpoint]" {
     run snazzer --list-snapshots --all "$MNT"
-    [ "$status" = "0" ]
     expected_list_snapshots_output > $(expected_file)
     echo "$output" > $(actual_file)
     diff -u $(expected_file) $(actual_file)
+    [ "$status" = "0" ]
 }
 
 @test "snazzer --list-snapshots --all [mountpoint/subvol]" {
@@ -65,20 +65,20 @@ HERE
 
 @test "snazzer --list-snapshots [/subvol1]" {
     run snazzer --list-snapshots "$MNT/home"
-    [ "$status" = "0" ]
     expected_list_snapshots_output | grep "^$MNT/home" > $(expected_file)
     echo "$output" > $(actual_file)
     diff -u $(expected_file) $(actual_file)
+    [ "$status" = "0" ]
 }
 
 @test "snazzer --list-snapshots [/subvol1] [/subvol2] [/subvol3]" {
     run snazzer --list-snapshots "$MNT/home" "$MNT/srv" "$MNT/var/cache"
-    [ "$status" = "0" ]
     expected_list_snapshots_output | \
         grep "^$MNT/\(home\|srv\|var/cache\)/\.snapshotz" | \
         sort > $(expected_file)
     echo "$output" > $(actual_file)
     diff -u $(expected_file) $(actual_file)
+    [ "$status" = "0" ]
 }
 
 teardown() {

--- a/tests/snazzer-prune.bats
+++ b/tests/snazzer-prune.bats
@@ -61,10 +61,10 @@ $SNAP"; else THIS=$SNAP; fi
 @test  "snazzer --prune --all --force [mountpoint]" {
     BEFORE=$(gather_snapshots | sort)
     run snazzer --prune --all --force "$MNT"
-    [ "$status" = "0" ]
     fake_prune "$BEFORE" > $(expected_file)
     gather_snapshots | sort > $(actual_file)
     diff -u $(expected_file) $(actual_file)
+    [ "$status" = "0" ]
 }
 
 @test  "snazzer --prune --all --dry-run [mountpoint]" {
@@ -75,25 +75,26 @@ $SNAP"; else THIS=$SNAP; fi
     fake_prune "$BEFORE" > $(expected_file)
     gather_snapshots | sort > $(actual_file)
     diff -u $(expected_file) $(actual_file)
+    [ "$status" = "0" ]
 }
 
 @test  "snazzer --prune --force [subvol]" {
     BEFORE=$(gather_snapshots | sort | grep "^$MNT/home/\.snapshotz")
     run snazzer --prune --force "$MNT/home"
-    [ "$status" = "0" ]
     echo "$BEFORE" | snazzer-prune-candidates --invert > $(expected_file)
     gather_snapshots | sort | grep "^$MNT/home/\.snapshotz" > $(actual_file)
     diff -u $(expected_file) $(actual_file)
+    [ "$status" = "0" ]
 }
 
 @test  "snazzer --prune --force [subvol1] [subvol2] [subvol3]" {
     BEFORE=$(gather_snapshots | sort | grep "^$MNT/\(home\|srv\|var/cache\)/\.snapshotz")
     run snazzer --prune --force "$MNT/home" "$MNT/srv" "$MNT"
-    [ "$status" = "0" ]
     fake_prune "$BEFORE" > $(expected_file)
     gather_snapshots | sort | \
         grep "^$MNT/\(home\|srv\|var/cache\)/\.snapshotz" > $(actual_file)
     diff -u $(expected_file) $(actual_file)
+    [ "$status" = "0" ]
 }
 
 teardown() {

--- a/tests/snazzer-prune.bats
+++ b/tests/snazzer-prune.bats
@@ -47,13 +47,10 @@ $SNAP"; else THIS=$SNAP; fi
     mkfs.btrfs --help
 }
 
-@test "snazzer-prune-candidates in PATH" {
-    local THIS_SNAZZER=$(readlink -f $BATS_TEST_DIRNAME/../snazzer-prune-candidates)
-    local PATH_SNAZZER=$(readlink -f $(which snazzer-prune-candidates))
-    
-    [ -n "$PATH_SNAZZER" ]
-    [ -n "$THIS_SNAZZER" ]
-    [ "$PATH_SNAZZER" = "$THIS_SNAZZER" ]
+@test "snazzer in PATH" {
+    readlink -f $BATS_TEST_DIRNAME/../snazzer > $(expected_file)
+    readlink -f $(which snazzer) > $(actual_file)
+    diff -u $(expected_file) $(actual_file)   
 }
 
 @test  "snazzer --prune --all [mountpoint]" {
@@ -65,31 +62,38 @@ $SNAP"; else THIS=$SNAP; fi
     BEFORE=$(gather_snapshots | sort)
     run snazzer --prune --all --force "$MNT"
     [ "$status" = "0" ]
-    [ "$(fake_prune "$BEFORE")" = "$(gather_snapshots | sort)" ]
+    fake_prune "$BEFORE" > $(expected_file)
+    gather_snapshots | sort > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
 }
 
 @test  "snazzer --prune --all --dry-run [mountpoint]" {
     BEFORE=$(gather_snapshots | sort)
     run snazzer --prune --all --dry-run "$MNT"
     [ "$status" = "0" ]
-    eval "$output" >/dev/null 2>/dev/null
-    [ "$(fake_prune "$BEFORE")" = "$(gather_snapshots | sort)" ]
+    eval "$output"
+    fake_prune "$BEFORE" > $(expected_file)
+    gather_snapshots | sort > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
 }
 
 @test  "snazzer --prune --force [subvol]" {
     BEFORE=$(gather_snapshots | sort | grep "^$MNT/home/\.snapshotz")
     run snazzer --prune --force "$MNT/home"
     [ "$status" = "0" ]
-    [ "$(echo "$BEFORE" | snazzer-prune-candidates --invert)" = \
-        "$(gather_snapshots | sort | grep "^$MNT/home/\.snapshotz")" ]
+    echo "$BEFORE" | snazzer-prune-candidates --invert > $(expected_file)
+    gather_snapshots | sort | grep "^$MNT/home/\.snapshotz" > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
 }
 
 @test  "snazzer --prune --force [subvol1] [subvol2] [subvol3]" {
     BEFORE=$(gather_snapshots | sort | grep "^$MNT/\(home\|srv\|var/cache\)/\.snapshotz")
     run snazzer --prune --force "$MNT/home" "$MNT/srv" "$MNT"
     [ "$status" = "0" ]
-    [ "$(fake_prune "$BEFORE")" = "$(gather_snapshots | sort | \
-        grep "^$MNT/\(home\|srv\|var/cache\)/\.snapshotz")" ]
+    fake_prune "$BEFORE" > $(expected_file)
+    gather_snapshots | sort | \
+        grep "^$MNT/\(home\|srv\|var/cache\)/\.snapshotz" > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
 }
 
 teardown() {

--- a/tests/snazzer-send-wrapper.bats
+++ b/tests/snazzer-send-wrapper.bats
@@ -13,6 +13,13 @@ setup() {
     cp "$BATS_TEST_DIRNAME/data/sudo" "$BATS_TMPDIR/snazzer-tests/bin/"
 }
 
+@test "snazzer-send-wrapper in PATH" {
+    readlink -f "$BATS_TMPDIR/snazzer-tests/bin/snazzer-send-wrapper" \
+        > $(expected_file)
+    readlink -f $(which snazzer-send-wrapper) > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
+}
+
 @test "snazzer-send-wrapper" {
     run snazzer-send-wrapper
     [ "$status" -eq "1" ]
@@ -21,13 +28,17 @@ setup() {
 @test "sudo -n snazzer --list-snapshots '--all'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "4" ]
+    echo "4" > $(expected_file)
+    echo "$output" > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "-n
+    echo "-n
 snazzer
 --list-snapshots
---all" ]
+--all" > $(expected_file b)
+    echo "$output" > $(actual_file b)
+    diff -u $(expected_file b) $(actual_file b)
 }
 
 @test "sudo -n snazzer --list-snapshots '--all' '--force'" {
@@ -43,10 +54,12 @@ snazzer
 @test "sudo -n snazzer --list-snapshots '--all' 'foo=\" some stuff \"' 'hel'\\\\'' squot '\\\\''lo' 'asd \" dquot \" fgh' 'ap ple' ' bon'\\\\''squot'\\\\''jour' 'there'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "10" ]
+    echo "10" > $(expected_file)
+    echo "$output" > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "-n
+    echo "-n
 snazzer
 --list-snapshots
 --all
@@ -55,14 +68,18 @@ hel' squot 'lo
 asd \" dquot \" fgh
 ap ple
  bon'squot'jour
-there" ]
+there" > $(expected_file b)
+    echo "$output" > $(actual_file b)
+    diff -u $(expected_file b) $(actual_file b)
 }
 
 # At some point we decided to error when args are switches, hence ^-prefix
 @test "sudo -n snazzer --list-snapshots 'bla' '^--bar' '^--cat=\" someone'\''s dog \"' '^--foo='\''a \"b\" c'\'''" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "7" ]
+    echo "7" > $(expected_file)
+    echo "$output" > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
 }
 
 @test "sudo -n snazzer --list-snapshots 'unbalance'd squote'" {
@@ -103,25 +120,34 @@ there" ]
 @test "sudo -n btrfs send '/subvol/.snapshotz/FOO'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "4" ]
+    echo "4" > $(expected_file)
+    echo "$output" > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "-n
+    echo "-n
 btrfs
 send
-/subvol/.snapshotz/FOO" ]
+/subvol/.snapshotz/FOO" > $(expected_file b)
+    echo "$output" > $(actual_file b)
+    diff -u $(expected_file b) $(actual_file b)
 }
 
 @test "sudo -n btrfs send '/echo \`ls \"/\"; ls /;\`; ~!@#\$(ls)%^&*()_+-='\\''[]'\\''{}|:<>,./?/.snapshotz/FOO2'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "4" ]
+    echo "4" > $(expected_file)
+    echo "$output" > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "-n
+    echo "-n
 btrfs
 send
-/echo \`ls \"/\"; ls /;\`; ~!@#\$(ls)%^&*()_+-='[]'{}|:<>,./?/.snapshotz/FOO2" ]
+/echo \`ls \"/\"; ls /;\`; ~!@#\$(ls)%^&*()_+-='[]'{}|:<>,./?/.snapshotz/FOO2" \
+    > $(expected_file b)
+    echo "$output" > $(actual_file b)
+    diff -u $(expected_file b) $(actual_file b)
 }
 
 @test "sudo -n btrfs send -p" {
@@ -137,15 +163,19 @@ send
 @test "sudo -n btrfs send '/subvol/.snapshotz/FOO2' '-p' '/subvol/.snapshotz/FOO1'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "6" ]
+    echo "6" > $(expected_file)
+    echo "$output" > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "-n
+    echo "-n
 btrfs
 send
 /subvol/.snapshotz/FOO2
 -p
-/subvol/.snapshotz/FOO1" ]
+/subvol/.snapshotz/FOO1" > $(expected_file b)
+    echo "$output" > $(actual_file b)
+    diff -u $(expected_file b) $(actual_file b)
 }
 
 @test "sudo -n btrfs send '/subvol/.snapshotz/FOO2' -p '/subvol/.snapshotz/FOO1'" {
@@ -156,27 +186,36 @@ send
 @test "sudo -n btrfs send '/echo \`ls \"/\"; ls /;\`; ~!@#\$(ls)%^&*()_+-='\\''[]'\\''{}|:<>,./?/.snapshotz/FOO2' '-p' '/echo \`ls \"/\"; ls /;\`; ~!@#\$(ls)%^&*()_+-='\\''[]'\\''{}|:<>,./?/.snapshotz/FOO1'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "6" ]
+    echo "6" > $(expected_file)
+    echo "$output" > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "-n
+    echo "-n
 btrfs
 send
 /echo \`ls \"/\"; ls /;\`; ~!@#\$(ls)%^&*()_+-='[]'{}|:<>,./?/.snapshotz/FOO2
 -p
-/echo \`ls \"/\"; ls /;\`; ~!@#\$(ls)%^&*()_+-='[]'{}|:<>,./?/.snapshotz/FOO1" ]
+/echo \`ls \"/\"; ls /;\`; ~!@#\$(ls)%^&*()_+-='[]'{}|:<>,./?/.snapshotz/FOO1" \
+    > $(expected_file b)
+    echo "$output" > $(actual_file b)
+    diff -u $(expected_file b) $(actual_file b)
 }
 
 @test "sudo -n btrfs send '/subvol/.snapshotz/F'\\''OO'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "4" ]
+    echo "4" > $(expected_file)
+    echo "$output" > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "-n
+    echo "-n
 btrfs
 send
-/subvol/.snapshotz/F'OO" ]
+/subvol/.snapshotz/F'OO" > $(expected_file b)
+    echo "$output" > $(actual_file b)
+    diff -u $(expected_file b) $(actual_file b)
 }
 
 @test "sudo -n btrfs send '/subvol/.snapshotz/F'OO'" {
@@ -199,27 +238,35 @@ send
 @test "sudo -n grep -srl '^> on foo1-host at ' '/subvol/.snapshotz/.measurements/'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "5" ]
+    echo "5" > $(expected_file)
+    echo "$output" > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "-n
+    echo "-n
 grep
 -srl
 ^> on foo1-host at 
-/subvol/.snapshotz/.measurements/" ]
+/subvol/.snapshotz/.measurements/" > $(expected_file b)
+    echo "$output" > $(actual_file b)
+    diff -u $(expected_file b) $(actual_file b)
 }
 
 @test "sudo -n grep -srl '^> on foo1-host at ' '/sub'\\''vol/.snapshotz/.measurements/'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "5" ]
+    echo "5" > $(expected_file)
+    echo "$output" > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "-n
+    echo "-n
 grep
 -srl
 ^> on foo1-host at 
-/sub'vol/.snapshotz/.measurements/" ]
+/sub'vol/.snapshotz/.measurements/" > $(expected_file b)
+    echo "$output" > $(actual_file b)
+    diff -u $(expected_file b) $(actual_file b)
 }
 
 @test "sudo -n grep -srl '^> on foo1-host at ' '/subvol/.snapshotz/.measurements/junk'" {
@@ -251,23 +298,31 @@ grep
 @test "sudo -n cat '/subvol/.snapshotz/.measurements/FOO'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "3" ]
+    echo "3" > $(expected_file)
+    echo "$output" > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "-n
+    echo "-n
 cat
-/subvol/.snapshotz/.measurements/FOO" ]
+/subvol/.snapshotz/.measurements/FOO" > $(expected_file b)
+    echo "$output" > $(actual_file b)
+    diff -u $(expected_file b) $(actual_file b)
 }
 
 @test "sudo -n cat '/sub'\\''vol/.snapshotz/.measurements/FOO'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "3" ]
+    echo "3" > $(expected_file)
+    echo "$output" > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
-    [ "$output" = "-n
+    echo "-n
 cat
-/sub'vol/.snapshotz/.measurements/FOO" ]
+/sub'vol/.snapshotz/.measurements/FOO" > $(expected_file b)
+    echo "$output" > $(actual_file b)
+    diff -u $(expected_file b) $(actual_file b)
 }
 
 @test "sudo -n cat" {

--- a/tests/snazzer-send-wrapper.bats
+++ b/tests/snazzer-send-wrapper.bats
@@ -27,18 +27,18 @@ setup() {
 
 @test "sudo -n snazzer --list-snapshots '--all'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
-    [ "$status" = "0" ]
     echo "4" > $(expected_file)
     echo "$output" > $(actual_file)
     diff -u $(expected_file) $(actual_file)
-    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
+    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     echo "-n
 snazzer
 --list-snapshots
 --all" > $(expected_file b)
     echo "$output" > $(actual_file b)
     diff -u $(expected_file b) $(actual_file b)
+    [ "$status" = "0" ]
 }
 
 @test "sudo -n snazzer --list-snapshots '--all' '--force'" {
@@ -53,12 +53,11 @@ snazzer
 
 @test "sudo -n snazzer --list-snapshots '--all' 'foo=\" some stuff \"' 'hel'\\\\'' squot '\\\\''lo' 'asd \" dquot \" fgh' 'ap ple' ' bon'\\\\''squot'\\\\''jour' 'there'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
-    [ "$status" = "0" ]
     echo "10" > $(expected_file)
     echo "$output" > $(actual_file)
     diff -u $(expected_file) $(actual_file)
-    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
+    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     echo "-n
 snazzer
 --list-snapshots
@@ -71,15 +70,16 @@ ap ple
 there" > $(expected_file b)
     echo "$output" > $(actual_file b)
     diff -u $(expected_file b) $(actual_file b)
+    [ "$status" = "0" ]
 }
 
 # At some point we decided to error when args are switches, hence ^-prefix
 @test "sudo -n snazzer --list-snapshots 'bla' '^--bar' '^--cat=\" someone'\''s dog \"' '^--foo='\''a \"b\" c'\'''" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
-    [ "$status" = "0" ]
     echo "7" > $(expected_file)
     echo "$output" > $(actual_file)
     diff -u $(expected_file) $(actual_file)
+    [ "$status" = "0" ]
 }
 
 @test "sudo -n snazzer --list-snapshots 'unbalance'd squote'" {
@@ -119,28 +119,27 @@ there" > $(expected_file b)
 
 @test "sudo -n btrfs send '/subvol/.snapshotz/FOO'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
-    [ "$status" = "0" ]
     echo "4" > $(expected_file)
     echo "$output" > $(actual_file)
     diff -u $(expected_file) $(actual_file)
-    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
+    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     echo "-n
 btrfs
 send
 /subvol/.snapshotz/FOO" > $(expected_file b)
     echo "$output" > $(actual_file b)
     diff -u $(expected_file b) $(actual_file b)
+    [ "$status" = "0" ]
 }
 
 @test "sudo -n btrfs send '/echo \`ls \"/\"; ls /;\`; ~!@#\$(ls)%^&*()_+-='\\''[]'\\''{}|:<>,./?/.snapshotz/FOO2'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
-    [ "$status" = "0" ]
     echo "4" > $(expected_file)
     echo "$output" > $(actual_file)
     diff -u $(expected_file) $(actual_file)
-    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
+    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     echo "-n
 btrfs
 send
@@ -148,6 +147,7 @@ send
     > $(expected_file b)
     echo "$output" > $(actual_file b)
     diff -u $(expected_file b) $(actual_file b)
+    [ "$status" = "0" ]
 }
 
 @test "sudo -n btrfs send -p" {
@@ -162,12 +162,11 @@ send
 
 @test "sudo -n btrfs send '/subvol/.snapshotz/FOO2' '-p' '/subvol/.snapshotz/FOO1'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
-    [ "$status" = "0" ]
     echo "6" > $(expected_file)
     echo "$output" > $(actual_file)
     diff -u $(expected_file) $(actual_file)
-    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
+    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     echo "-n
 btrfs
 send
@@ -176,6 +175,7 @@ send
 /subvol/.snapshotz/FOO1" > $(expected_file b)
     echo "$output" > $(actual_file b)
     diff -u $(expected_file b) $(actual_file b)
+    [ "$status" = "0" ]
 }
 
 @test "sudo -n btrfs send '/subvol/.snapshotz/FOO2' -p '/subvol/.snapshotz/FOO1'" {
@@ -185,12 +185,11 @@ send
 
 @test "sudo -n btrfs send '/echo \`ls \"/\"; ls /;\`; ~!@#\$(ls)%^&*()_+-='\\''[]'\\''{}|:<>,./?/.snapshotz/FOO2' '-p' '/echo \`ls \"/\"; ls /;\`; ~!@#\$(ls)%^&*()_+-='\\''[]'\\''{}|:<>,./?/.snapshotz/FOO1'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
-    [ "$status" = "0" ]
     echo "6" > $(expected_file)
     echo "$output" > $(actual_file)
     diff -u $(expected_file) $(actual_file)
-    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
+    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     echo "-n
 btrfs
 send
@@ -200,22 +199,23 @@ send
     > $(expected_file b)
     echo "$output" > $(actual_file b)
     diff -u $(expected_file b) $(actual_file b)
+    [ "$status" = "0" ]
 }
 
 @test "sudo -n btrfs send '/subvol/.snapshotz/F'\\''OO'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
-    [ "$status" = "0" ]
     echo "4" > $(expected_file)
     echo "$output" > $(actual_file)
     diff -u $(expected_file) $(actual_file)
-    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
+    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     echo "-n
 btrfs
 send
 /subvol/.snapshotz/F'OO" > $(expected_file b)
     echo "$output" > $(actual_file b)
     diff -u $(expected_file b) $(actual_file b)
+    [ "$status" = "0" ]
 }
 
 @test "sudo -n btrfs send '/subvol/.snapshotz/F'OO'" {
@@ -237,12 +237,11 @@ send
 
 @test "sudo -n grep -srl '^> on foo1-host at ' '/subvol/.snapshotz/.measurements/'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
-    [ "$status" = "0" ]
     echo "5" > $(expected_file)
     echo "$output" > $(actual_file)
     diff -u $(expected_file) $(actual_file)
-    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
+    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     echo "-n
 grep
 -srl
@@ -250,16 +249,16 @@ grep
 /subvol/.snapshotz/.measurements/" > $(expected_file b)
     echo "$output" > $(actual_file b)
     diff -u $(expected_file b) $(actual_file b)
+    [ "$status" = "0" ]
 }
 
 @test "sudo -n grep -srl '^> on foo1-host at ' '/sub'\\''vol/.snapshotz/.measurements/'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
-    [ "$status" = "0" ]
     echo "5" > $(expected_file)
     echo "$output" > $(actual_file)
     diff -u $(expected_file) $(actual_file)
-    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
+    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     echo "-n
 grep
 -srl
@@ -267,6 +266,7 @@ grep
 /sub'vol/.snapshotz/.measurements/" > $(expected_file b)
     echo "$output" > $(actual_file b)
     diff -u $(expected_file b) $(actual_file b)
+    [ "$status" = "0" ]
 }
 
 @test "sudo -n grep -srl '^> on foo1-host at ' '/subvol/.snapshotz/.measurements/junk'" {
@@ -297,32 +297,32 @@ grep
 
 @test "sudo -n cat '/subvol/.snapshotz/.measurements/FOO'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
-    [ "$status" = "0" ]
     echo "3" > $(expected_file)
     echo "$output" > $(actual_file)
     diff -u $(expected_file) $(actual_file)
-    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
+    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     echo "-n
 cat
 /subvol/.snapshotz/.measurements/FOO" > $(expected_file b)
     echo "$output" > $(actual_file b)
     diff -u $(expected_file b) $(actual_file b)
+    [ "$status" = "0" ]
 }
 
 @test "sudo -n cat '/sub'\\''vol/.snapshotz/.measurements/FOO'" {
     SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=no_args run snazzer-send-wrapper
-    [ "$status" = "0" ]
     echo "3" > $(expected_file)
     echo "$output" > $(actual_file)
     diff -u $(expected_file) $(actual_file)
-    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     [ "$status" = "0" ]
+    SSH_ORIGINAL_COMMAND="$BATS_TEST_DESCRIPTION" F=ls_args run snazzer-send-wrapper
     echo "-n
 cat
 /sub'vol/.snapshotz/.measurements/FOO" > $(expected_file b)
     echo "$output" > $(actual_file b)
     diff -u $(expected_file b) $(actual_file b)
+    [ "$status" = "0" ]
 }
 
 @test "sudo -n cat" {

--- a/tests/snazzer.bats
+++ b/tests/snazzer.bats
@@ -7,6 +7,7 @@ setup() {
     export SNAZZER_SUBVOLS_EXCLUDE_FILE=$BATS_TEST_DIRNAME/data/exclude.patterns
     export SNAZZER_DATE=$(date +"%Y-%m-%dT%H%M%S%z")
     export MNT=$(prepare_mnt)
+    export SNAZZER_TMP=$BATS_TMPDIR/snazzer-tests
     [ -e "$SNAZZER_SUBVOLS_EXCLUDE_FILE" ]
 }
 
@@ -33,40 +34,44 @@ expected_snapshots_raw() {
 }
 
 @test "snazzer in PATH" {
-    local THIS_SNAZZER=$(readlink -f $BATS_TEST_DIRNAME/../snazzer)
-    local PATH_SNAZZER=$(readlink -f $(which snazzer))
-    
-    [ -n "$PATH_SNAZZER" ]
-    [ -n "$THIS_SNAZZER" ]
-    [ "$PATH_SNAZZER" = "$THIS_SNAZZER" ]
+    readlink -f $BATS_TEST_DIRNAME/../snazzer > $(expected_file)
+    readlink -f $(which snazzer) > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
 }
 
 @test "snazzer --all [mountpoint]" {
     run snazzer --all "$MNT"
     [ "$status" = "0" ]
-    [ "$(expected_snapshots | sort)" = "$(gather_snapshots | sort)" ]
+    expected_snapshots | sort > $(expected_file)
+    gather_snapshots | sort > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
 }
 
 @test "snazzer --dry-run --all [mountpoint]" {
     run snazzer --dry-run --all "$MNT"
     [ "$status" = "0" ]
-    eval "$output" >/dev/null 2>/dev/null
-    [ "$(expected_snapshots | sort)" = "$(gather_snapshots | sort)" ]
+    eval "$output"
+    [ "$status" = "0" ]
+    expected_snapshots | sort > $(expected_file)
+    gather_snapshots | sort > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
 }
 
 @test "snazzer [subvol]" {
     run snazzer "$MNT/home"
     [ "$status" = "0" ]
-    [ "$(expected_snapshots_raw | grep "^$MNT/home")" = \
-        "$(gather_snapshots | sort)" ]
+    expected_snapshots_raw | grep "^$MNT/home" > $(expected_file)
+    gather_snapshots | sort > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
 }
 
 @test "snazzer [subvol1] [subvol2] [subvol3]" {
     run snazzer "$MNT/home" "$MNT/srv" "$MNT/var/cache"
     [ "$status" = "0" ]
-    [ "$(expected_snapshots_raw | \
-        grep "^$MNT/\(home\|srv\|var/cache\)/\.snapshotz" | sort)" = \
-        "$(gather_snapshots | sort)" ]
+    expected_snapshots_raw | grep "^$MNT/\(home\|srv\|var/cache\)/\.snapshotz" \
+        | sort > $(expected_file)
+    gather_snapshots | sort > $(actual_file)
+    diff -u $(expected_file) $(actual_file)
 }
 
 teardown() {

--- a/tests/snazzer.bats
+++ b/tests/snazzer.bats
@@ -41,37 +41,37 @@ expected_snapshots_raw() {
 
 @test "snazzer --all [mountpoint]" {
     run snazzer --all "$MNT"
-    [ "$status" = "0" ]
     expected_snapshots | sort > $(expected_file)
     gather_snapshots | sort > $(actual_file)
     diff -u $(expected_file) $(actual_file)
+    [ "$status" = "0" ]
 }
 
 @test "snazzer --dry-run --all [mountpoint]" {
     run snazzer --dry-run --all "$MNT"
     [ "$status" = "0" ]
     eval "$output"
-    [ "$status" = "0" ]
     expected_snapshots | sort > $(expected_file)
     gather_snapshots | sort > $(actual_file)
     diff -u $(expected_file) $(actual_file)
+    [ "$status" = "0" ]
 }
 
 @test "snazzer [subvol]" {
     run snazzer "$MNT/home"
-    [ "$status" = "0" ]
     expected_snapshots_raw | grep "^$MNT/home" > $(expected_file)
     gather_snapshots | sort > $(actual_file)
     diff -u $(expected_file) $(actual_file)
+    [ "$status" = "0" ]
 }
 
 @test "snazzer [subvol1] [subvol2] [subvol3]" {
     run snazzer "$MNT/home" "$MNT/srv" "$MNT/var/cache"
-    [ "$status" = "0" ]
     expected_snapshots_raw | grep "^$MNT/\(home\|srv\|var/cache\)/\.snapshotz" \
         | sort > $(expected_file)
     gather_snapshots | sort > $(actual_file)
     diff -u $(expected_file) $(actual_file)
+    [ "$status" = "0" ]
 }
 
 teardown() {


### PR DESCRIPTION
Let's use diff -u expected actual rather than [ "$foo" = "bar" ].

This should make bats emit something useful when tests fail rather
than a simple line number in the tests that failed.

Closes #42